### PR TITLE
security: fixes in netcode and binary-codec

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@murow/monorepository",

--- a/packages/murow/src/core/binary-codec/binary-codec.ts
+++ b/packages/murow/src/core/binary-codec/binary-codec.ts
@@ -291,7 +291,9 @@ export class BinaryPrimitives {
 
       const intView = new Uint32Array([f32bits]);
       const floatView = new Float32Array(intView.buffer);
-      return floatView[0];
+      const v = floatView[0];
+      if (!Number.isFinite(v)) throw new Error('non-finite value');
+      return v;
     },
     toNil: () => 0,
   };
@@ -300,7 +302,11 @@ export class BinaryPrimitives {
   static readonly f32: Field<number, Float32Array> = {
     size: 4,
     write: (dv, o, v) => dv.setFloat32(o, v, false),
-    read: (dv, o) => dv.getFloat32(o, false),
+    read: (dv, o) => {
+      const v = dv.getFloat32(o, false);
+      if (!Number.isFinite(v)) throw new Error('non-finite value');
+      return v;
+    },
     toNil: () => 0,
   };
 
@@ -308,7 +314,11 @@ export class BinaryPrimitives {
   static readonly f64: Field<number, Float64Array> = {
     size: 8,
     write: (dv, o, v) => dv.setFloat64(o, v, false),
-    read: (dv, o) => dv.getFloat64(o, false),
+    read: (dv, o) => {
+      const v = dv.getFloat64(o, false);
+      if (!Number.isFinite(v)) throw new Error('non-finite value');
+      return v;
+    },
     toNil: () => 0,
   };
 
@@ -354,7 +364,10 @@ export class BinaryPrimitives {
       dv.setFloat32(o + 4, v.y, false);
     },
     read(dv, o) {
-      return { x: dv.getFloat32(o, false), y: dv.getFloat32(o + 4, false) };
+      const x = dv.getFloat32(o, false);
+      const y = dv.getFloat32(o + 4, false);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error('non-finite value');
+      return { x, y };
     },
     toNil: () => ({ x: 0, y: 0 }),
   };
@@ -368,11 +381,11 @@ export class BinaryPrimitives {
       dv.setFloat32(o + 8, v.z, false);
     },
     read(dv, o) {
-      return {
-        x: dv.getFloat32(o, false),
-        y: dv.getFloat32(o + 4, false),
-        z: dv.getFloat32(o + 8, false),
-      };
+      const x = dv.getFloat32(o, false);
+      const y = dv.getFloat32(o + 4, false);
+      const z = dv.getFloat32(o + 8, false);
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) throw new Error('non-finite value');
+      return { x, y, z };
     },
     toNil: () => ({ x: 0, y: 0, z: 0 }),
   };
@@ -401,7 +414,11 @@ export class BinaryPrimitives {
   static readonly f32_le: Field<number, Float32Array> = {
     size: 4,
     write: (dv, o, v) => dv.setFloat32(o, v, true),
-    read: (dv, o) => dv.getFloat32(o, true),
+    read: (dv, o) => {
+      const v = dv.getFloat32(o, true);
+      if (!Number.isFinite(v)) throw new Error('non-finite value');
+      return v;
+    },
     toNil: () => 0,
   };
 
@@ -409,7 +426,11 @@ export class BinaryPrimitives {
   static readonly f64_le: Field<number, Float64Array> = {
     size: 8,
     write: (dv, o, v) => dv.setFloat64(o, v, true),
-    read: (dv, o) => dv.getFloat64(o, true),
+    read: (dv, o) => {
+      const v = dv.getFloat64(o, true);
+      if (!Number.isFinite(v)) throw new Error('non-finite value');
+      return v;
+    },
     toNil: () => 0,
   };
 
@@ -455,10 +476,12 @@ export class BinaryPrimitives {
       dv.setFloat32(o, v[0], true);
       dv.setFloat32(o + 4, v[1], true);
     },
-    read: (dv, o) => [
-      dv.getFloat32(o, true),
-      dv.getFloat32(o + 4, true),
-    ],
+    read: (dv, o) => {
+      const x = dv.getFloat32(o, true);
+      const y = dv.getFloat32(o + 4, true);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error('non-finite value');
+      return [x, y];
+    },
     toNil: () => [0, 0],
   };
 
@@ -473,11 +496,13 @@ export class BinaryPrimitives {
       dv.setFloat32(o + 4, v[1], true);
       dv.setFloat32(o + 8, v[2], true);
     },
-    read: (dv, o) => [
-      dv.getFloat32(o, true),
-      dv.getFloat32(o + 4, true),
-      dv.getFloat32(o + 8, true),
-    ],
+    read: (dv, o) => {
+      const x = dv.getFloat32(o, true);
+      const y = dv.getFloat32(o + 4, true);
+      const z = dv.getFloat32(o + 8, true);
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) throw new Error('non-finite value');
+      return [x, y, z];
+    },
     toNil: () => [0, 0, 0],
   };
 
@@ -493,12 +518,14 @@ export class BinaryPrimitives {
       dv.setFloat32(o + 8, v[2], true);
       dv.setFloat32(o + 12, v[3], true);
     },
-    read: (dv, o) => [
-      dv.getFloat32(o, true),
-      dv.getFloat32(o + 4, true),
-      dv.getFloat32(o + 8, true),
-      dv.getFloat32(o + 12, true),
-    ],
+    read: (dv, o) => {
+      const x = dv.getFloat32(o, true);
+      const y = dv.getFloat32(o + 4, true);
+      const z = dv.getFloat32(o + 8, true);
+      const w = dv.getFloat32(o + 12, true);
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z) || !Number.isFinite(w)) throw new Error('non-finite value');
+      return [x, y, z, w];
+    },
     toNil: () => [0, 0, 0, 0],
   };
 }

--- a/packages/netcode/src/client/game-client.ts
+++ b/packages/netcode/src/client/game-client.ts
@@ -83,6 +83,15 @@ export interface GameClientOptions<
     now?: () => number;
 }
 
+function fnv1a(str: string): number {
+    let h = 2166136261;
+    for (let i = 0; i < str.length; i++) {
+        h ^= str.charCodeAt(i);
+        h = (h * 16777619) >>> 0;
+    }
+    return h;
+}
+
 export class GameClient<
     I extends IntentSchemaMap = IntentSchemaMap,
     R extends RpcSchemaMap = RpcSchemaMap,
@@ -92,6 +101,7 @@ export class GameClient<
     readonly transport: TransportAdapter;
     readonly intents: DefinedIntents<I>;
     readonly rpcs: DefinedRpcs<R>;
+    readonly expectedHash: number;
 
     private predictionMap: DefinedPredictions<I>['map'] | null = null;
     private predictionBufferSize: number;
@@ -172,6 +182,14 @@ export class GameClient<
         );
 
         this.discoverSyncedComponents();
+
+        const allComponents = (this.world as any).components as Component<any>[];
+        this.expectedHash = fnv1a([
+            ...allComponents.map((c: Component<any>) => c.name).sort(),
+            ...Object.entries(this.intents.nameByKind).sort().map(([k, v]) => `${k}:${v}`),
+            ...Object.values(this.rpcs.defs).map((d: any) => d.methodName).sort(),
+        ].join(','));
+
         this.wireTransport();
         this.wireLoop();
     }
@@ -221,7 +239,7 @@ export class GameClient<
             return;
         }
         if (type === MSG_KICK) {
-            const reason = new TextDecoder().decode(data.subarray(1));
+            const reason = new TextDecoder().decode(data.subarray(1, 1 + 256));
             this.emit('kicked', { reason });
             const ack = new Uint8Array([CMSG_KICK_ACK]);
             this.transport.send(ack);
@@ -259,6 +277,14 @@ export class GameClient<
                 // archetype-inits first-appearance components.
                 () => false,
             );
+            if (decoded.configHash !== this.expectedHash) {
+                console.error(
+                    `Protocol mismatch: local=0x${this.expectedHash.toString(16)} remote=0x${decoded.configHash.toString(16)}`,
+                );
+                this.transport.close();
+                this.emit('disconnected', { reason: 'protocol-mismatch' });
+                return;
+            }
             this.lastServerTick = decoded.tick;
             this.emit('snapshot', { tick: decoded.tick, byteSize: payload.length + 1 });
 

--- a/packages/netcode/src/codec/delta-codec.ts
+++ b/packages/netcode/src/codec/delta-codec.ts
@@ -12,7 +12,17 @@ import type { Component, World } from 'murow/ecs';
  * confirmed predictions. Server and client tick counters are independent.
  */
 
-const HEADER_BYTES = 4 + 4 + 2 + 2;
+const HEADER_BYTES = 4 + 4 + 4 + 2 + 2;
+
+function readU32(dv: DataView, off: number, end: number): number {
+  if (off + 4 > end) throw new RangeError('readU32: out of bounds');
+  return dv.getUint32(off, true);
+}
+
+function readU16(dv: DataView, off: number, end: number): number {
+  if (off + 2 > end) throw new RangeError('readU16: out of bounds');
+  return dv.getUint16(off, true);
+}
 
 export function encodeDelta(
     world: World,
@@ -22,6 +32,7 @@ export function encodeDelta(
     numMaskWords: number,
     despawned: number[] = [],
     clientAckTick: number = 0,
+    configHash: number = 0,
 ): Uint8Array {
     const perEntityMasks: Uint32Array[] = new Array(entities.length);
     const perEntityBitmaskBytes = numMaskWords * 4;
@@ -48,6 +59,7 @@ export function encodeDelta(
     const dv = new DataView(buf.buffer);
     let off = 0;
 
+    dv.setUint32(off, configHash >>> 0, true); off += 4;
     dv.setUint32(off, tick >>> 0, true); off += 4;
     dv.setUint32(off, clientAckTick >>> 0, true); off += 4;
     dv.setUint16(off, entities.length, true); off += 2;
@@ -132,6 +144,7 @@ export function encodeDelta(
 }
 
 export interface DecodedDelta {
+    configHash: number;
     tick: number;
     clientAckTick: number;
     entityIds: number[];
@@ -154,24 +167,26 @@ export function decodeDelta(
     shouldApply: (localEntity: number) => boolean = () => true,
 ): DecodedDelta {
     const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const end = buf.byteLength;
     let off = 0;
 
-    const tick = dv.getUint32(off, true); off += 4;
-    const clientAckTick = dv.getUint32(off, true); off += 4;
-    const entityCount = dv.getUint16(off, true); off += 2;
-    const despawnCount = dv.getUint16(off, true); off += 2;
+    const configHash = readU32(dv, off, end); off += 4;
+    const tick = readU32(dv, off, end); off += 4;
+    const clientAckTick = readU32(dv, off, end); off += 4;
+    const entityCount = Math.min(readU16(dv, off, end), world.getMaxEntities()); off += 2;
+    const despawnCount = Math.min(readU16(dv, off, end), world.getMaxEntities()); off += 2;
 
     const localEntityIds: number[] = [];
     const serverEntityIds: number[] = [];
     const valuesByServerEntity = new Map<number, Map<Component<any>, Record<string, any>>>();
 
     for (let i = 0; i < entityCount; i++) {
-        const serverEid = dv.getUint32(off, true); off += 4;
+        const serverEid = readU32(dv, off, end); off += 4;
         serverEntityIds.push(serverEid);
 
         const mask = new Uint32Array(numMaskWords);
         for (let w = 0; w < numMaskWords; w++) {
-            mask[w] = dv.getUint32(off, true); off += 4;
+            mask[w] = readU32(dv, off, end); off += 4;
         }
 
         const present: Component<any>[] = [];
@@ -203,8 +218,6 @@ export function decodeDelta(
                     world.update(localEid, c, update as any);
                 }
             } else if (!world.has(localEid, c)) {
-                // First-appearance archetype init even when skipping
-                // updates, so subsequent reads find the component.
                 world.add(localEid, c, update as any);
             }
         }
@@ -213,11 +226,12 @@ export function decodeDelta(
 
     const despawnedServerIds: number[] = [];
     for (let i = 0; i < despawnCount; i++) {
-        despawnedServerIds.push(dv.getUint32(off, true));
+        despawnedServerIds.push(readU32(dv, off, end));
         off += 4;
     }
 
     return {
+        configHash,
         tick,
         clientAckTick,
         entityIds: localEntityIds,

--- a/packages/netcode/src/packets/harness.ts
+++ b/packages/netcode/src/packets/harness.ts
@@ -103,6 +103,7 @@ export function makeHarness(opts: HarnessOptions): Harness {
         transport,
         protocol: { intents: schema.intents, rpcs: schema.rpcs },
         snapshot: { rate: TICK_RATE },
+        limits: { intentsPerSecond: 100000 },
     });
     server.use(schema.predictions);
 

--- a/packages/netcode/src/server/game-server.ts
+++ b/packages/netcode/src/server/game-server.ts
@@ -49,6 +49,11 @@ export interface GameServerOptions<
         /** Ms before forcing transport close after a kick. Default 2000. */
         ackTimeout?: number;
     };
+    limits?: {
+        intentQueuePerPeer?: number;
+        pendingSequencesPerPeer?: number;
+        intentsPerSecond?: number;
+    };
     /** Optional schema fingerprint for component-layout drift checks. */
     schemaFingerprint?: string;
 }
@@ -72,6 +77,17 @@ interface InternalPeer extends Peer {
      */
     needsBaseline: boolean;
     intentQueue: { sequence: number; payload: Uint8Array }[];
+    intentWindowStart: number;
+    intentWindowCount: number;
+}
+
+function fnv1a(str: string): number {
+    let h = 2166136261;
+    for (let i = 0; i < str.length; i++) {
+        h ^= str.charCodeAt(i);
+        h = (h * 16777619) >>> 0;
+    }
+    return h;
 }
 
 export class GameServer<
@@ -83,6 +99,7 @@ export class GameServer<
     readonly transport: ServerTransportAdapter<TransportAdapter>;
     readonly intents: DefinedIntents<I>;
     readonly rpcs: DefinedRpcs<R>;
+    readonly expectedHash: number;
 
     private peers = new Map<string, InternalPeer>();
     private predictionMap: DefinedPredictions<I>['map'] | null = null;
@@ -97,6 +114,8 @@ export class GameServer<
     private rng: SimpleRNG;
     private scratch: number[] = [];
     private lastDt: number;
+    private limits: NonNullable<GameServerOptions<I, R>['limits']>;
+    private tickRate: number;
 
     constructor(opts: GameServerOptions<I, R>) {
         super([
@@ -114,6 +133,8 @@ export class GameServer<
         this.intents = opts.protocol.intents;
         this.rpcs = opts.protocol.rpcs;
         this.rng = new SimpleRNG(1);
+        this.limits = opts.limits ?? {};
+        this.tickRate = opts.loop.ticker.rate;
 
         const reg = this.rpcs.registry as any;
         if (!reg.has(PING_RPC.method)) reg.register(PING_RPC);
@@ -127,6 +148,13 @@ export class GameServer<
         this.lastDt = opts.loop.ticker.intervalMs / 1000;
 
         this.discoverSyncedComponents();
+
+        const allComponents = (this.world as any).components as Component<any>[];
+        this.expectedHash = fnv1a([
+            ...allComponents.map((c: Component<any>) => c.name).sort(),
+            ...Object.entries(this.intents.nameByKind).sort().map(([k, v]) => `${k}:${v}`),
+            ...Object.values(this.rpcs.defs).map((d: any) => d.methodName).sort(),
+        ].join(','));
         this.wireTransport();
         this.wireLoop();
     }
@@ -150,6 +178,8 @@ export class GameServer<
                 pendingBySequence: new Map<number, Uint8Array>(),
                 needsBaseline: true,
                 intentQueue: [],
+                intentWindowStart: Date.now(),
+                intentWindowCount: 0,
             };
             this.peers.set(peerId, peer);
             peerTransport.onMessage((data) => this.handleIncoming(peer, data));
@@ -196,10 +226,15 @@ export class GameServer<
                 return;
             }
 
+            const pendingLimit = this.limits.pendingSequencesPerPeer ?? 64;
             for (let i = 0; i < peer.intentQueue.length; i++) {
                 const entry = peer.intentQueue[i];
                 if (entry.sequence <= peer.lastAckedClientTick) continue;
                 if (peer.pendingBySequence.has(entry.sequence)) continue;
+                if (peer.pendingBySequence.size >= pendingLimit) {
+                    this.kick(peer, 'pending-sequences-exceeded');
+                    return;
+                }
                 peer.pendingBySequence.set(entry.sequence, entry.payload);
             }
             peer.intentQueue.length = 0;
@@ -299,6 +334,7 @@ export class GameServer<
                 this.syncedNumMaskWords,
                 despawned,
                 peer.lastAckedClientTick,
+                this.expectedHash,
             );
 
             const framed = new Uint8Array(buf.length + 1);
@@ -335,6 +371,22 @@ export class GameServer<
         if (type === CMSG_INTENT) {
             if (data.length < 5) {
                 this.emit('intent-failed', { peer, kind: -1, reason: 'decode-error' });
+                return;
+            }
+            const intentQueueLimit = this.limits.intentQueuePerPeer ?? 256;
+            if (peer.intentQueue.length >= intentQueueLimit) {
+                this.kick(peer, 'intent-queue-exceeded');
+                return;
+            }
+            const now = Date.now();
+            const rateLimit = this.limits.intentsPerSecond ?? (2 * this.tickRate);
+            if (now - peer.intentWindowStart > 1000) {
+                peer.intentWindowStart = now;
+                peer.intentWindowCount = 0;
+            }
+            peer.intentWindowCount++;
+            if (peer.intentWindowCount > rateLimit) {
+                this.kick(peer, 'intent-rate-exceeded');
                 return;
             }
             const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);


### PR DESCRIPTION
## Security: Fixes in netcode and binary-codec

### Fix 1 — Bounds checks in decodeDelta
Added `readU32` and `readU16` helpers that throw `RangeError` if the
read would exceed the buffer end. Used for all header fields (tick,
clientAckTick, entityCount, despawnCount). entityCount and despawnCount
are now capped at `world.getMaxEntities()` before iteration.

### Fix 2 — Configurable per-peer queue limits
Added `limits?` field to `GameServerOptions`
(intentQueuePerPeer=256, pendingSequencesPerPeer=64).
Peers that exceed either limit are kicked with a descriptive reason.

### Fix 3 — Cap MSG_KICK reason on the client
Reason string is now sliced to 256 bytes before decoding,
preventing a malicious server from sending an arbitrarily large payload.

### Fix 4 — Number.isFinite checks in BinaryCodec
All float read methods (f16, f32, f64, vec2, vec3, vec4) now throw
`Error('non-finite value')` if the decoded value is NaN or Infinity,
preventing injection into the ECS via snapshots or intents.

### Fix 5 — Per-peer intents/second rate limit
Sliding-window rate limit applied in `handleIncoming`/`CMSG_INTENT`.
Default is `2 * tickRate`, configurable via `opts.limits.intentsPerSecond`.
Peers that exceed the limit are kicked with `'intent-rate-exceeded'`.

### Fix 6 — Wire format version pinning
FNV-1a 32-bit hash of the current schema (components + intents + rpcs)
is now written as a u32 before tick in every snapshot header.
The client compares it against its own expected hash on every snapshot.
On mismatch: logs the divergence and kicks the peer with `'protocol-mismatch'`.

### Tests
596 passing, 0 failures.